### PR TITLE
Add configurable shutdown timeout

### DIFF
--- a/app/config/Config.go
+++ b/app/config/Config.go
@@ -15,14 +15,15 @@ type Config struct {
 
 // AppConfig holds application configurations.
 type AppConfig struct {
-	Name     string        `yaml:"name"`
-	Mode     string        `yaml:"mode"`
-	Host     string        `yaml:"host"`
-	Port     int           `yaml:"port"`
-	Timeout  TimeoutConfig `yaml:"timeout"`
-	Timezone string        `yaml:"timezone"`
-	Metrics  MetricConfig  `yaml:"metrics"`
-	Cache    CacheConfig   `yaml:"cache"`
+	Name            string        `yaml:"name"`
+	Mode            string        `yaml:"mode"`
+	Host            string        `yaml:"host"`
+	Port            int           `yaml:"port"`
+	Timeout         TimeoutConfig `yaml:"timeout"`
+	ShutdownTimeout DurString     `yaml:"shutdown-timeout"`
+	Timezone        string        `yaml:"timezone"`
+	Metrics         MetricConfig  `yaml:"metrics"`
+	Cache           CacheConfig   `yaml:"cache"`
 }
 
 type DurString string

--- a/app/config/renderer.go
+++ b/app/config/renderer.go
@@ -28,6 +28,7 @@ func (cfg AppConfig) RenderAsTable() string {
 		{"Host", cfg.Host},
 		{"Port", cfg.Port},
 		{"Timezone", cfg.Timezone},
+		{"Shutdown Timeout", cfg.ShutdownTimeout},
 		{"Metrics Enabled", cfg.Metrics.Enabled},
 	}
 	if cfg.Metrics.Enabled {

--- a/configs/app.yaml
+++ b/configs/app.yaml
@@ -2,11 +2,12 @@ name: storybuilder
 mode: DEBUG
 host:
 port: 3000
-timezone: GMT+0530
 timeout:
   write: 15s
   read: 15s
   idle: 60s
+shutdown-timeout: 15s
+timezone: GMT+0530
 metrics:
   enabled: false
   port: 3001

--- a/main.go
+++ b/main.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"os"
 	"os/signal"
-	"time"
 
 	"github.com/storybuilder/storybuilder/app/config"
 	"github.com/storybuilder/storybuilder/app/container"
@@ -34,7 +33,7 @@ func main() {
 	// block until a registered signal is received
 	<-c
 	// create a deadline to wait for
-	var wait time.Duration
+	wait := cfg.AppConfig.ShutdownTimeout.Dur()
 	// Doesn't block if no connections, but will otherwise wait
 	// until the timeout deadline.
 	ctx, cancel := context.WithTimeout(context.Background(), wait)


### PR DESCRIPTION
## Summary
- enable graceful shutdown to wait for pending requests using configurable timeout
- expose `shutdown-timeout` option in app configuration and rendering

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a37bbd8e7c832aa1f80ab1dd9d4fd0