### PR TITLE
Refactor slice iteration to use traditional loops

### DIFF
--- a/externals/repositories/SampleSQLRepository.go
+++ b/externals/repositories/SampleSQLRepository.go
@@ -3,7 +3,6 @@ package repositories
 import (
 	"context"
 	"fmt"
-	"slices"
 
 	"github.com/storybuilder/storybuilder/domain/boundary/adapters"
 	"github.com/storybuilder/storybuilder/domain/boundary/repositories"
@@ -113,7 +112,7 @@ func (repo *SampleSQLRepository) mapResult(result []map[string]any) (samples []e
 			err, _ = r.(error)
 		}
 	}()
-	for row := range slices.Values(result) {
+	for _, row := range result {
 		samples = append(samples, entities.Sample{
 			ID:   int(row["id"].(int64)),
 			Name: string(row["name"].([]byte)),

--- a/transport/http/error/formatter.go
+++ b/transport/http/error/formatter.go
@@ -3,9 +3,8 @@ package error
 import (
 	"encoding/json"
 	"errors"
-	"strings"
-	"slices"
 	"maps"
+	"strings"
 
 	"github.com/iancoleman/strcase"
 
@@ -115,7 +114,7 @@ func formatKey(k string) string {
 	kParts := strings.Split(k, ".")
 	// remove unpacker name
 	kParts = kParts[1:]
-	for i, part := range slices.All(kParts) {
+	for i, part := range kParts {
 		kParts[i] = strcase.ToSnake(part)
 	}
 	return strings.Join(kParts, ".")

--- a/transport/http/middleware/CORSMiddleware.go
+++ b/transport/http/middleware/CORSMiddleware.go
@@ -2,7 +2,6 @@ package middleware
 
 import (
 	"net/http"
-	"slices"
 	"strings"
 
 	"github.com/storybuilder/storybuilder/app/config"
@@ -28,7 +27,7 @@ func (m CORSMiddleware) Middleware(next http.Handler) http.Handler {
 		if len(m.allowedOrigins) == 1 && m.allowedOrigins[0] == "*" {
 			allowedOrigin = "*"
 		} else {
-			for o := range slices.Values(m.allowedOrigins) {
+			for _, o := range m.allowedOrigins {
 				if o == origin {
 					allowedOrigin = origin
 					break

--- a/transport/http/middleware/RequestCheckerMiddleware.go
+++ b/transport/http/middleware/RequestCheckerMiddleware.go
@@ -3,7 +3,6 @@ package middleware
 import (
 	"fmt"
 	"net/http"
-	"slices"
 	"strings"
 
 	"github.com/storybuilder/storybuilder/app/container"
@@ -29,7 +28,7 @@ func NewRequestCheckerMiddleware(ctr *container.Container) *RequestCheckerMiddle
 func (m *RequestCheckerMiddleware) Middleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		reqURL := r.URL.String()
-		for v := range slices.Values(m.omittedRoutes) {
+		for _, v := range m.omittedRoutes {
 			if strings.HasPrefix(reqURL, v) {
 				next.ServeHTTP(w, r)
 				return

--- a/transport/http/response/transformer.go
+++ b/transport/http/response/transformer.go
@@ -1,8 +1,6 @@
 package response
 
 import (
-	"slices"
-
 	"github.com/storybuilder/storybuilder/transport/http/response/mappers"
 	"github.com/storybuilder/storybuilder/transport/http/response/transformers"
 )
@@ -17,7 +15,7 @@ func Transform(data any, t transformers.TransformerInterface, isCollection bool)
 
 // Map wraps payload in a standard response payload object.
 func Map(data []any) (m mappers.Payload) {
-	for v := range slices.Values(data) {
+	for _, v := range data {
 		switch v.(type) {
 		default:
 			m.Data = v

--- a/transport/http/response/transformers/SampleTransformer.go
+++ b/transport/http/response/transformers/SampleTransformer.go
@@ -1,8 +1,6 @@
 package transformers
 
 import (
-	"slices"
-
 	"github.com/storybuilder/storybuilder/domain/entities"
 	"github.com/storybuilder/storybuilder/transport/http/errors"
 )
@@ -40,7 +38,7 @@ func (t *SampleTransformer) TransformAsCollection(data any) (any, error) {
 	if !ok {
 		return nil, t.dataMismatchError()
 	}
-	for sample := range slices.Values(samples) {
+	for _, sample := range samples {
 		tr, err := t.TransformAsObject(sample)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Replaced instances of `slices.Values` and `slices.All` with standard `for _, v := range data` or `for i, v := range data` where applicable to ensure idiomatic usage. `slices.Values` and `slices.All` should be preserved for generic function sequences as outlined by Go 1.23 best practices. Removed the resulting unused `slices` imports from the modified files.

---
*PR created automatically by Jules for task [5247193987151900044](https://jules.google.com/task/5247193987151900044) started by @ruwanego*